### PR TITLE
Fix cookie path

### DIFF
--- a/dependencies/nodejs/response.js
+++ b/dependencies/nodejs/response.js
@@ -15,7 +15,7 @@ class Response {
     this.body = ''
   }
   updateCookie (cookie) {
-    this.headers['Set-Cookie'] = cookie
+    this.headers['Set-Cookie'] = cookie + '; Path=/v2' // This prevents the path from defaulting to /v2/auth on Firefox.
   }
   redirect (url) {
     return {


### PR DESCRIPTION
Without this fix, the cookies' paths aren't being set correctly in Firefox. This prevents JWT data from being included in requests to api routes outside of /v2/auth.