### PR TITLE
Made package installable & private

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,26 @@
 {
+  "name": "lambda common layer",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
+  "packages": {
+    "": {
+      "name": "lambda common layer",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^8.2.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  },
   "dependencies": {
     "dotenv": {
       "version": "8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
-  "name": "lambda common layer",
+  "name": "sustainability-office-lambda-common-layer",
   "version": "1.0.0",
-  "description": "",
+  "description": "Lambda common layer for the Sustainability Office AWS services.",
   "main": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
+  "private":true,
+  "files":[
+    "/dependencies/"
+  ],
+  "author": "Oregon State University: Office of Sustainability",
   "license": "MIT",
   "dependencies": {
     "dotenv": "^8.2.0"


### PR DESCRIPTION
I'm making this PR to make it so we can install the lambda common layer as a node dependency for the Energy Dashboard's backend unit testing.  I don't feel super strongly about including the common layer in the dashboard repo, so if you have any reasons to deny the PR that's all good (just make sure to also delete the branch if possible).

### Summary of Changes
I added & modified some properties inside the `package.json` file.  Here's an itemized list of changes and what they do:

##### 1. Changed `name` to `sustainability-office-lambda-common-layer`:
This makes it so we can install the package from the git repo; the previous name had spaces in it which prevented npm from installing it remotely.

##### 2. Added property of `private` and set it to `true`: 
This property prevents npm from pushing the package to the public npm registry.

##### 3. Added "files" property, included "`/dependcies/`" in its array:
This doesn't actually affect much, it just ensures that node will include the dependencies folder when installing (this is what's used by most of the lambda functions for the energy-dashboard).
 
The other changes I made were purely semantic and just intended to make the package.json look more professional.

### Why I think this is a good idea:
If we can locally install the lambda common layer in other projects then we can easily write unit tests for the back-end lambda functions.  The main alternatives seem to be adding the entire repo as a [`git subtree`](https://www.atlassian.com/git/tutorials/git-subtree) or [`git submodule`](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to other projects, both of which would add some amount of complexity to interfacing with those git repositories.  

The major downside I see would be remembering to update the node package in each repository after making a change to the lambda common layer (although this downside I think also applies to git subtrees & submodules).

