### PR TITLE
Github Actions - Needs work on Encryption

### DIFF
--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -1,0 +1,37 @@
+name: SAM Deployment
+on:
+  push:
+    branches:
+      - gh-actions-ci
+jobs:
+  deploy-sam:
+    name: Deploy Serveless API
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with: 
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/setup-python@v2
+    - uses: aws-actions/setup-sam@v2
+      with:
+        version: 1.59.0
+    - uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
+    - name: Set-up Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12
+    - name: npm install
+      run: npm install --prefix=dependencies/nodejs install --loglevel=verbose
+    - name: OpenSSL Encryption
+      run: openssl aes-256-cbc -K $encrypted_a4267a9c202b_key -iv $encrypted_a4267a9c202b_iv -in .env.enc -out ./dependencies/nodejs/.env -d
+    - name: Deploy
+      working-directory: backend
+      run: |
+        sam validate
+        sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
+        
+#sam deploy --template-file /home/runner/work/energy-dashboard/energy-dashboard/backend/packaged.yaml --stack-name auth --capabilities CAPABILITY_IAM --region us-west-2 --no-confirm-changeset --no-fail-on-empty-changeset

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -2,7 +2,7 @@ name: SAM Deployment
 on:
   push:
     branches:
-      - gh-actions-ci
+      - master
 jobs:
   deploy-sam:
     name: Deploy Serveless API
@@ -26,12 +26,15 @@ jobs:
         node-version: 12
     - name: npm install
       run: npm install --prefix=dependencies/nodejs install --loglevel=verbose
-    - name: OpenSSL Encryption
-      run: openssl aes-256-cbc -K $encrypted_a4267a9c202b_key -iv $encrypted_a4267a9c202b_iv -in .env.enc -out ./dependencies/nodejs/.env -d
+
+# Encryption part needs work
+# - name: OpenSSL Encryption
+# run: openssl aes-256-cbc -K $encrypted_a4267a9c202b_key -iv $encrypted_a4267a9c202b_iv -in .env.enc -out ./dependencies/nodejs/.env -d
+
     - name: Deploy
-      working-directory: backend
       run: |
         sam validate
         sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
         
-#sam deploy --template-file /home/runner/work/energy-dashboard/energy-dashboard/backend/packaged.yaml --stack-name auth --capabilities CAPABILITY_IAM --region us-west-2 --no-confirm-changeset --no-fail-on-empty-changeset
+#sam deploy --template-file /home/runner/work/auth/auth/packaged.yaml --stack-name auth --capabilities CAPABILITY_IAM --region us-west-2 --no-confirm-changeset --no-fail-on-empty-changeset
+# Note: deploy path above is not tested and could be wrong. A successful run with sam package should show deploy path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "lambda common layer",
+  "name": "sustainability-office-lambda-common-layer",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "lambda common layer",
+      "name": "sustainability-office-lambda-common-layer",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## NOT COMPLETE

Referenced Issue: https://github.com/OSU-Sustainability-Office/lambda-common-layer/issues/30

`Api-deploy.yml` is a mostly complete Github Actions pipeline, but the encryption needs work (need to rethink how we are encrypting maybe), and also the `sam deploy` path is untested.

We might transition to AWS Secret Manager or Github Secrets or something like that, instead of including encrypted env files in the repository.

AWS Secrets Manager:
- https://aws.amazon.com/secrets-manager/