### PR TITLE
Remove credentials

### DIFF
--- a/dependencies/nodejs/response.js
+++ b/dependencies/nodejs/response.js
@@ -14,17 +14,14 @@ class Response {
     if (originHeader) {
       this.headers = {
         'Access-Control-Allow-Origin': originHeader,
-        'Access-Control-Allow-Credentials': 'true'
       }
     } else if (refererHeader) {
       this.headers = {
         'Access-Control-Allow-Origin': refererHeader,
-        'Access-Control-Allow-Credentials': 'true'
       }
     } else {
       this.headers = {
         'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Credentials': 'true'
       }
     }
 


### PR DESCRIPTION
The Access-Control-Allow-Credentials field in HTTP is used to handle cookies, authorization headers, or TLS client certificates, all of which being vital for user login sessions. This is leftover code as we are no longer working on user sessions. Thus, it can be removed.