### PR TITLE
Integrate AWS Cloudformation update-stack into the pipeline to automatically update Energy Dashboard function layer version

### DIFF
--- a/.github/workflows/LCL-deploy.yml
+++ b/.github/workflows/LCL-deploy.yml
@@ -1,6 +1,6 @@
 name: Lambda Common Layer Deployment
 on:
-  pull_request:
+  push:
     branches:
       - master
 jobs:

--- a/.github/workflows/LCL-deploy.yml
+++ b/.github/workflows/LCL-deploy.yml
@@ -33,3 +33,20 @@ jobs:
         sam validate
         sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
         sam deploy --template-file ./packaged.yaml --stack-name auth --capabilities CAPABILITY_IAM --no-confirm-changeset --no-fail-on-empty-changeset
+    - name: Fetch latest layer ARN
+      id: layer
+      run: |
+        ARN=$(aws cloudformation describe-stacks \
+                --stack-name auth \
+                --query 'Stacks[0].Outputs[?OutputKey==`LambdaCommonLayerArn`].OutputValue' \
+                --output text)
+        echo "layer_arn=$ARN" >> "$GITHUB_OUTPUT"
+    - name: Update dependent stack parameters for energy dashboard
+      run: |
+        aws cloudformation update-stack \
+          --stack-name energy \
+          --use-previous-template \
+          --parameters \
+            ParameterKey=LambdaCommonLayer,ParameterValue=${{ steps.layer.outputs.layer_arn }} \
+          --capabilities CAPABILITY_IAM
+    

--- a/.github/workflows/LCL-deploy.yml
+++ b/.github/workflows/LCL-deploy.yml
@@ -24,15 +24,19 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 20
+
     - name: npm install
       run: npm install --prefix=dependencies/nodejs install --loglevel=verbose
+
     - name: env encrpytion
       run: openssl aes-256-cbc -K ${{ secrets.ENV_KEY }} -iv ${{ secrets.ENV_IV }} -in .env.enc -out ./dependencies/nodejs/.env -d
+
     - name: Deploy
       run: |
         sam validate
         sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
         sam deploy --template-file ./packaged.yaml --stack-name auth --capabilities CAPABILITY_IAM --no-confirm-changeset --no-fail-on-empty-changeset
+
     - name: Fetch latest layer ARN
       id: layer
       run: |
@@ -41,7 +45,18 @@ jobs:
                 --query 'Stacks[0].Outputs[?OutputKey==`LambdaCommonLayerArn`].OutputValue' \
                 --output text)
         echo "layer_arn=$ARN" >> "$GITHUB_OUTPUT"
-    - name: Update dependent stack parameters for energy dashboard
+
+    - name: Check if layer ARN changed
+      id: check_layer
+      run: |
+        CURRENT_ARN=$(aws cloudformation describe-stacks \
+                --stack-name energy \
+                --query 'Stacks[0].Parameters[?ParameterKey==`LambdaCommonLayer`].ParameterValue' \
+                --output text)
+        echo "current=$CURRENT_ARN" >> "$GITHUB_OUTPUT"
+
+    - name: Update dependent stack parameters for energy dashboard if layer ARN changed
+      if: steps.layer.outputs.layer_arn != steps.check_layer.outputs.current
       run: |
         aws cloudformation update-stack \
           --stack-name energy \

--- a/.github/workflows/LCL-deploy.yml
+++ b/.github/workflows/LCL-deploy.yml
@@ -1,6 +1,6 @@
 name: Lambda Common Layer Deployment
 on:
-  push:
+  pull_request:
     branches:
       - master
 jobs:

--- a/dependencies/nodejs/response.js
+++ b/dependencies/nodejs/response.js
@@ -10,7 +10,6 @@ class Response {
     const normalizedHeaders = event.headers || {}
     const originHeader = normalizedHeaders.origin || normalizedHeaders.Origin
     const refererHeader = normalizedHeaders.referer || normalizedHeaders.Referer
-    console.log('test version')
 
     if (originHeader) {
       this.headers = {

--- a/dependencies/nodejs/response.js
+++ b/dependencies/nodejs/response.js
@@ -10,6 +10,7 @@ class Response {
     const normalizedHeaders = event.headers || {}
     const originHeader = normalizedHeaders.origin || normalizedHeaders.Origin
     const refererHeader = normalizedHeaders.referer || normalizedHeaders.Referer
+    console.log('test version')
 
     if (originHeader) {
       this.headers = {

--- a/dependencies/nodejs/response.js
+++ b/dependencies/nodejs/response.js
@@ -14,14 +14,17 @@ class Response {
     if (originHeader) {
       this.headers = {
         'Access-Control-Allow-Origin': originHeader,
+        'Access-Control-Allow-Credentials': 'true'
       }
     } else if (refererHeader) {
       this.headers = {
         'Access-Control-Allow-Origin': refererHeader,
+        'Access-Control-Allow-Credentials': 'true'
       }
     } else {
       this.headers = {
         'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Credentials': 'true'
       }
     }
 

--- a/dependencies/nodejs/sql-access.js
+++ b/dependencies/nodejs/sql-access.js
@@ -23,9 +23,9 @@ export function connect(database) {
       state.db.connect(function (err) {
         if (err) {
           console.error('Database connection failed: ' + err.stack)
-          return
+          return reject(err)
         }
-        resolve()
+        resolve(state.db)
       })
     }
   })

--- a/template.yaml
+++ b/template.yaml
@@ -45,3 +45,10 @@ Resources:
               - nodejs20.x
             LicenseInfo: 'MIT'
             RetentionPolicy: Retain
+
+Outputs:
+  LambdaCommonLayerArn:
+    Description: Latest versioned ARN of the common layer
+    Value: !Ref LambdaCommonLayer
+    Export:
+      Name: LambdaCommonLayerArn # exported for use in other stacks 


### PR DESCRIPTION
### Summary ### 
Before this PR, the Energy Dashboard lambdas were stuck on an old Lambda Common Layer version because there was no step to update the CloudFormation stack when a new layer was published. This change adds a CI/CD job that detects when the layer version has changed and automatically triggers a stack update so the dashboard always uses the latest layer.